### PR TITLE
Fixed throwing an error with anonymous users

### DIFF
--- a/Security/Firewall/OAuthListener.php
+++ b/Security/Firewall/OAuthListener.php
@@ -67,7 +67,7 @@ class OAuthListener
     public function handle(RequestEvent $event): void
     {
         if (null === $oauthToken = $this->serverService->getBearerToken($event->getRequest(), true)) {
-            throw new LogicException('Token for event was null');
+            return;
         }
 
         $token = new OAuthToken();

--- a/Tests/Security/Firewall/OAuthListenerTest.php
+++ b/Tests/Security/Firewall/OAuthListenerTest.php
@@ -130,4 +130,30 @@ class OAuthListenerTest extends TestCase
         // no return, trigger the expectations
         $listener->handle($this->event);
     }
+
+    public function testHandleAnonymousAuthentication(): void
+    {
+        $listener = new OAuthListener($this->tokenStorage, $this->authManager, $this->serverService);
+
+        $this->serverService
+            ->expects($this->once())
+            ->method('getBearerToken')
+            ->willReturn(null)
+        ;
+
+        $this->tokenStorage
+            ->expects($this->never())
+            ->method('setToken')
+        ;
+
+	    $this->event
+		    ->expects($this->never())
+		    ->method('setResponse')
+	    ;
+
+        // no return, trigger the expectations
+        $listener->handle($this->event);
+
+	    $this->assertNull($this->tokenStorage->getToken());
+    }
 }


### PR DESCRIPTION
I now had the situation that I want to deliver a function to anonymous users.
And then I'm wondering why I always get this `Token for event was null` error - until I find out that the original repository returns nothing there while this symfony-5 implementation throws an exception.

So I added a test for anonymous users and fixed the problem.

If there is another sense for this throwing logic exception you can explain me how I can enable anonymous users - because the user is only anonymous when all authentications are returning null = AnonymousToken instead OAuthToken